### PR TITLE
Add types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Boolean operations on polygons (union, intersection, difference, xor)",
   "main": "dist/polybool.cjs",
   "module": "dist/polybool.js",
+  "types": "dist/polybool.d.ts",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
Fixes importing package into Typescript project
with compilerOptions.moduleResolution = node

Would help out a Vite Vue project: https://github.com/Kitware/VolView/pull/617